### PR TITLE
Improve code style and apply cs fixes

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -9,9 +9,6 @@ return PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
-        'ordered_imports' => ['sortAlgorithm' => 'length'],
-        'no_unused_imports' => true,
-        'native_function_invocation' => true,
         'is_null' => true,
         'list_syntax' => [
             'syntax' => 'short',
@@ -23,5 +20,8 @@ return PhpCsFixer\Config::create()
         'native_constant_invocation' => true,
         'native_function_casing' => true,
         'new_with_braces' => true,
+        'no_unused_imports' => true,
+        'ordered_imports' => ['sortAlgorithm' => 'length'],
+        'return_type_declaration' => ['space_before' => 'none'],
     ])
     ->setFinder($finder);

--- a/src/CallbackFilter.php
+++ b/src/CallbackFilter.php
@@ -6,7 +6,7 @@ namespace SimpleStreamFilter;
 
 final class CallbackFilter extends \php_user_filter
 {
-    public function filter($in, $out, &$consumed, $closing) : int
+    public function filter($in, $out, &$consumed, $closing): int
     {
         $bucket = \stream_bucket_make_writeable($in);
 

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -49,7 +49,7 @@ final class Filter
     /**
      * @param resource $filter
      */
-    public static function remove($filter) : void
+    public static function remove($filter): void
     {
         self::assertResource($filter);
 
@@ -58,7 +58,7 @@ final class Filter
         }
     }
 
-    private static function registeredFilter() : string
+    private static function registeredFilter(): string
     {
         if (self::$callbackFilterName === null) {
             $return = \stream_filter_register(
@@ -74,7 +74,7 @@ final class Filter
         return self::$callbackFilterName;
     }
 
-    private static function assertResource($resource) : void
+    private static function assertResource($resource): void
     {
         if (!\is_resource($resource)) {
             throw new \InvalidArgumentException('Must be a valid resource.');

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class FilterTest extends TestCase
 {
-    public function testAppend() : void
+    public function testAppend(): void
     {
         $stream = $this->createStream('<b>HELLO WORLD</b>');
 
@@ -20,7 +20,7 @@ class FilterTest extends TestCase
         \fclose($stream);
     }
 
-    public function testPrependAfterAppend() : void
+    public function testPrependAfterAppend(): void
     {
         $stream = $this->createStream();
 
@@ -41,7 +41,7 @@ class FilterTest extends TestCase
         \fclose($stream);
     }
 
-    public function testAppendMultipleFilters() : void
+    public function testAppendMultipleFilters(): void
     {
         $stream = $this->createStream('<b>HELLO WORLD</b>');
 
@@ -58,7 +58,7 @@ class FilterTest extends TestCase
         \fclose($stream);
     }
 
-    public function testAppendUsingClassAsCallback() : void
+    public function testAppendUsingClassAsCallback(): void
     {
         $stream = $this->createStream('<b>HELLO WORLD</b>');
 
@@ -74,7 +74,7 @@ class FilterTest extends TestCase
         \fclose($stream);
     }
 
-    public function testAppendBuffer() : void
+    public function testAppendBuffer(): void
     {
         $stream = $this->createStream();
 
@@ -98,7 +98,7 @@ class FilterTest extends TestCase
         \fclose($stream);
     }
 
-    public function testRemoveFilter() : void
+    public function testRemoveFilter(): void
     {
         $stream = $this->createStream();
 


### PR DESCRIPTION
This adjusts a few return types declaration to remove the first space.

PSR12 is not 100% clear about that specific space, but they run a pool and the [opposite was not approved](https://github.com/php-fig/fig-standards/pull/733).

I think PSR12 will introduce this rule and since PSR12 rule in [PHP CS is not ready yet](https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4502) I manually added this rule here.